### PR TITLE
Set up .gitignore to avoid committing unwanted files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# System files
+.DS_Store
+Thumbs.db
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Python
+__pycache__/
+*.py[cod]
+*.env
+*.venv
+env/
+venv/
+
+# Editor settings
+.vscode/
+.idea/
+*.sublime-workspace
+*.sublime-project
+
+# Logs
+*.log
+logs/
+*.log.*
+
+# Build outputs
+dist/
+build/
+
+# Misc
+*.swp
+*.bak
+*.tmp
+coverage/


### PR DESCRIPTION
This PR adds a `.gitignore` file to help keep the repository clean by ignoring files and folders that don't need to be tracked by Git.
Ignored files/folders:- 
1)node_modules, 
2).env, 
3)build
This restricts any accidental changes to sensitive files.